### PR TITLE
Add query methods for entities to the root schedule object

### DIFF
--- a/pygtfs/schedule.py
+++ b/pygtfs/schedule.py
@@ -64,9 +64,28 @@ def _meta_query_by_id(entity, docstring=None):
         _query_by_id.__doc__ = docstring
     return _query_by_id
 
+
+def _meta_query_raw(entity, docstring=None):
+    def _query_raw(instance_self):
+        """
+            A raw sqlalchemy query object that the user can then manipulate
+            manually
+        """
+        return instance_self.session.query(entity)
+
+    if docstring is not None:
+        _query_raw.__doc__ = docstring
+    return property(_query_raw)
+
+
 for entity in (gtfs_all + [Feed]):
     entity_doc = "A list of :py:class:`pygtfs.gtfs_entities.{0}` objects".format(entity.__name__)
+    entity_raw_doc = ("A :py:class:`sqlalchemy.orm.Query` object to fetch "
+                      ":py:class:`pygtfs.gtfs_entities.{0}` objects"
+                      .format(entity.__name__))
     entity_by_id_doc = "A list of :py:class:`pygtfs.gtfs_entities.{0}` objects with matching id".format(entity.__name__)
     setattr(Schedule, entity._plural_name_, _meta_query_all(entity, entity_doc))
+    setattr(Schedule, entity._plural_name_ + "_query",
+            _meta_query_raw(entity, entity_raw_doc))
     if hasattr(entity, 'id'):
         setattr(Schedule, entity._plural_name_ + "_by_id", _meta_query_by_id(entity, entity_by_id_doc))    

--- a/pygtfs/test/test.py
+++ b/pygtfs/test/test.py
@@ -13,6 +13,8 @@ except ImportError:
 from pygtfs import overwrite_feed
 from pygtfs import Schedule
 
+from sqlalchemy.orm import Query
+
 
 class TestSchedule(unittest.TestCase):
     def setUp(self):
@@ -78,6 +80,17 @@ class TestSchedule(unittest.TestCase):
         with self.assertRaises(ValueError):
             t.bikes_allowed = -1
         self.assertEqual(t.bikes_allowed, 2)
+    
+    def test_query_methods(self):
+        """
+            Test that the object query getters return
+            :py:class:`sqlalchemy.orm.Query` objects
+        """
+        # Ideally assertIsInstance would be used, but this is not Python 2.6
+        # compatile
+        self.assertEqual(isinstance(self.schedule.agencies_query, Query),
+                         True)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Problem I am trying to solve:

When using your package, I thought that it would be easier to be able to access the raw `sqlalchemy` query objects, so that advanced filtering/loading can be performed by the user.

For example - when working with a large schedule, I have found it useful to preload some related objects from the database to reduce the number of queries that are triggered. As it stands, this requires manually using the schedule's session method.

Contents of the patch:

This patch adds a new set of properties to the `schedule` object of the form `<Entity>_query`. They closely follow the pattern of the existing properties.

I have also added a unit test to cover the new behaviour.

I am happy to make further changes based on feedback - for example I have not added any docs so far as I was not sure where to put them.