### PR TITLE
drop Python2.6 from testing and setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 language: python
 sudo: false
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
-  - "pypy"
-  - "pypy3"
+  - "3.6"
+  - "pypy3.5"
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   - pip install six sqlalchemy pytz docopt
 script:
   - python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,12 @@ setup(
         "Operating System :: OS Independent",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5"
+        "Programming Language :: Python :: 3.6"
+        "Programming Language :: Python :: 3.7"
         ]
 )


### PR DESCRIPTION
Our dependencies (e.g. sqlalchemy) are dropping 2.6. It's time
to drop it too. This removes 2.6 from travis.