### PR TITLE
Add postgres loading travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 language: python
 sudo: false
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
   - "3.6"
+  - "3.5"
+  - "3.4"
+  - "3.3"
+  - "2.7"
   - "pypy3.5"
+matrix:
+  include:
+  - name: "postgres gtfs load test"
+    services:
+      - postgresql
+    install:
+      - pip install six sqlalchemy pytz docopt psycopg2-binary
+    script:
+      - python -m pygtfs.gtfs2db append test/data/sample_feed/ postgresql://postgres@localhost:5432
 install:
   - pip install six sqlalchemy pytz docopt
 script:

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5"
-        "Programming Language :: Python :: 3.6"
-        "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         ]
 )


### PR DESCRIPTION
Add a postgres loading travis test

This adds a `gtfs2db` loading to postgres step to the travis matrix.
It currently fails, because of #31, and hopefully will help make sure
we fix it properly.

Also changes the python version order, because travis picks the first
version for matrix-included items.