### PR TITLE
Ignore supplied `feed_id`s.

### DIFF
--- a/pygtfs/loader.py
+++ b/pygtfs/loader.py
@@ -56,7 +56,10 @@ def append_feed(schedule, feed_filename, strip_fields=True,
         gtfs_filename = gtfs_class.__tablename__ + '.txt'
 
         try:
-            gtfs_tables[gtfs_class] = fd.read_table(gtfs_filename, gtfs_class.__table__.columns)
+            # We ignore the feed supplied feed id, because we create our own
+            # later.
+            gtfs_tables[gtfs_class] = fd.read_table(gtfs_filename,
+                                                    set(c.name for c in gtfs_class.__table__.columns) - {'feed_id'})
         except (KeyError, IOError):
             if gtfs_class in gtfs_required:
                 raise IOError('Error: could not find %s' % gtfs_filename)

--- a/pygtfs/test/data/sample_feed/feed_info.txt
+++ b/pygtfs/test/data/sample_feed/feed_info.txt
@@ -1,0 +1,2 @@
+feed_publisher_name,feed_publisher_url,url_lang,feed_id
+the feeder,transit.example.com,en,17


### PR DESCRIPTION
Some feeds have their own `feed_id`. This is not in the spec. But
we should ignore fields we don't understand.

Fixes #55