### PR TITLE
Add support for trip-to-trip and route-to-route transfers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ matrix:
       - postgresql
     install:
       - pip install six sqlalchemy pytz docopt psycopg2-binary
-      - curl -O https://www.bart.gov/sites/default/files/docs/google_transit_20180910_v13.zip
+      - curl -o bart_gtfs.zip https://www.bart.gov/sites/default/files/docs/google_transit_20211001_20220213_v1.zip
     script:
-      - python -m pygtfs.gtfs2db append google_transit_20180910_v13.zip postgresql://postgres@localhost:5432
+      - python -m pygtfs.gtfs2db append bart_gtfs.zip postgresql://postgres@localhost:5432
 install:
   - pip install six sqlalchemy pytz docopt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
       - pip install six sqlalchemy pytz docopt psycopg2-binary
     script:
       - python -m pygtfs.gtfs2db append pygtfs/test/data/sample_feed/ postgresql://postgres@localhost:5432
+    python: 3.9
   - name: "postgres + bart gtfs load test"
     services:
       - postgresql
@@ -25,6 +26,7 @@ matrix:
       - curl -o bart_gtfs.zip https://www.bart.gov/sites/default/files/docs/google_transit_20211001_20220213_v1.zip
     script:
       - python -m pygtfs.gtfs2db append bart_gtfs.zip postgresql://postgres@localhost:5432
+    python: 3.9
 install:
   - pip install six sqlalchemy pytz docopt
 script:

--- a/pygtfs/gtfs_entities.py
+++ b/pygtfs/gtfs_entities.py
@@ -154,7 +154,7 @@ class Stop(Base):
     zone_id = Column(Unicode, nullable=True)
     stop_url = Column(Unicode, nullable=True)
     location_type = Column(Integer, nullable=True)
-    parent_station = Column(Integer, nullable=True)
+    parent_station = Column(Unicode, nullable=True)
     stop_timezone = Column(Unicode, nullable=True)
     wheelchair_boarding = Column(Integer, nullable=True)
     platform_code = Column(Unicode, nullable=True)

--- a/pygtfs/gtfs_entities.py
+++ b/pygtfs/gtfs_entities.py
@@ -517,9 +517,9 @@ class Transfer(Base):
                                                    'transfer_type')
 
     def __repr__(self):
-        return f"<Transfer from " \
-               + "({self.from_stop_id}, {self.from_route_id}, {self.from_trip_id}) " \
-               + "to ({self.to_stop_id}, {self.to_route_id} ,{self.to_trip_id})>"
+        return "<Transfer from (%s, %s, %s) to (%s, %s, %s)>" % (self.from_stop_id, self.from_route_id,
+                                                                 self.from_trip_id, self.to_stop_id,
+                                                                 self.to_route_id, self.to_trip_id)
 
 
 class FeedInfo(Base):

--- a/pygtfs/gtfs_entities.py
+++ b/pygtfs/gtfs_entities.py
@@ -478,20 +478,17 @@ class Transfer(Base):
     feed_id = Column(Integer, ForeignKey('_feed.feed_id'), primary_key=True)
     from_stop_id = Column(Unicode, primary_key=True)
     to_stop_id = Column(Unicode, primary_key=True)
-    from_route_id = Column(Unicode, primary_key=True, nullable=True)
-    to_route_id = Column(Unicode, primary_key=True, nullable=True)
-    from_trip_id = Column(Unicode, primary_key=True, nullable=True)
-    to_trip_id = Column(Unicode, primary_key=True, nullable=True)
+    # Not null with default empty string to keep PostgreSQL happy
+    from_route_id = Column(Unicode, primary_key=True, nullable=False, default="")
+    to_route_id = Column(Unicode, primary_key=True, nullable=False, default="")
+    from_trip_id = Column(Unicode, primary_key=True, nullable=False, default="")
+    to_trip_id = Column(Unicode, primary_key=True, nullable=False, default="")
     transfer_type = Column(Integer, nullable=True)  # required; allowed empty
     min_transfer_time = Column(Integer, nullable=True)
 
     __table_args__ = (
         ForeignKeyConstraint([feed_id, from_stop_id], [Stop.feed_id, Stop.stop_id]),
         ForeignKeyConstraint([feed_id, to_stop_id], [Stop.feed_id, Stop.stop_id]),
-        ForeignKeyConstraint([feed_id, from_route_id], [Route.feed_id, Route.route_id]),
-        ForeignKeyConstraint([feed_id, to_route_id], [Route.feed_id, Route.route_id]),
-        ForeignKeyConstraint([feed_id, from_trip_id], [Trip.feed_id, Trip.trip_id]),
-        ForeignKeyConstraint([feed_id, to_trip_id], [Trip.feed_id, Trip.trip_id]),
     )
 
     stop_to = relationship(Stop, backref="transfers_to",

--- a/pygtfs/test/data/sample_feed/transfers.txt
+++ b/pygtfs/test/data/sample_feed/transfers.txt
@@ -1,0 +1,4 @@
+transfer_type,from_stop_id,to_stop_id,from_route_id,to_route_id,from_trip_id,to_trip_id
+0,FUR_CREEK_RES,BEATTY_AIRPORT,,,,
+3,FUR_CREEK_RES,BEATTY_AIRPORT,,,AAMV2,AAMV4
+1,FUR_CREEK_RES,BEATTY_AIRPORT,AAMV,STBA,,

--- a/pygtfs/test/test.py
+++ b/pygtfs/test/test.py
@@ -75,9 +75,9 @@ class TestSchedule(unittest.TestCase):
         self.assertEqual(0, len(self.schedule.stops[1].transfers_from))
         self.assertEqual(3, len(self.schedule.stops[1].transfers_to))
         self.assertEqual([
-            (0, 'BEATTY_AIRPORT', None, None),
-            (3, 'BEATTY_AIRPORT', None, 'AAMV4'),
-            (1, 'BEATTY_AIRPORT', 'STBA', None),
+            (0, 'BEATTY_AIRPORT', '', ''),
+            (3, 'BEATTY_AIRPORT', '', 'AAMV4'),
+            (1, 'BEATTY_AIRPORT', 'STBA', ''),
         ], [(tr.transfer_type, tr.to_stop_id, tr.to_route_id, tr.to_trip_id) for tr in self.schedule.stops[1].transfers_to])
 
     def test_transfers_route_to_route(self):

--- a/pygtfs/test/test.py
+++ b/pygtfs/test/test.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals
 
 import datetime
 import os.path
-# use unittest2 for Python2.6 compatibility. 
+
+# use unittest2 for Python2.6 compatibility.
 try:
     import unittest2 as unittest
 except ImportError:
@@ -67,6 +68,37 @@ class TestSchedule(unittest.TestCase):
     def test_agency_routes(self):
         self.assertEqual([rt.route_id for rt in self.schedule.agencies[0].routes],
                          ['AAMV', 'AB', 'BFC', 'CITY', 'EXT', 'STBA'])
+
+    def test_transfers(self):
+        self.assertEqual(3, len(self.schedule.stops[0].transfers_from))
+        self.assertEqual(0, len(self.schedule.stops[0].transfers_to))
+        self.assertEqual(0, len(self.schedule.stops[1].transfers_from))
+        self.assertEqual(3, len(self.schedule.stops[1].transfers_to))
+        self.assertEqual([
+            (0, 'BEATTY_AIRPORT', None, None),
+            (3, 'BEATTY_AIRPORT', None, 'AAMV4'),
+            (1, 'BEATTY_AIRPORT', 'STBA', None),
+        ], [(tr.transfer_type, tr.to_stop_id, tr.to_route_id, tr.to_trip_id) for tr in self.schedule.stops[1].transfers_to])
+
+    def test_transfers_route_to_route(self):
+        self.assertEqual(1, len(self.schedule.agencies[0].routes[0].transfers_from))
+        self.assertEqual(0, len(self.schedule.agencies[0].routes[0].transfers_to))
+        self.assertEqual(0, len(self.schedule.agencies[0].routes[5].transfers_from))
+        self.assertEqual(1, len(self.schedule.agencies[0].routes[5].transfers_to))
+        self.assertEqual([1], [tr.transfer_type for tr in self.schedule.agencies[0].routes[0].transfers_from])
+        self.assertEqual([], [tr.transfer_type for tr in self.schedule.agencies[0].routes[0].transfers_to])
+        self.assertEqual([], [tr.transfer_type for tr in self.schedule.agencies[0].routes[5].transfers_from])
+        self.assertEqual([1], [tr.transfer_type for tr in self.schedule.agencies[0].routes[5].transfers_to])
+
+    def test_transfers_trip_to_trip(self):
+        self.assertEqual(1, len(self.schedule.trips[8].transfers_from))
+        self.assertEqual(0, len(self.schedule.trips[8].transfers_to))
+        self.assertEqual(0, len(self.schedule.trips[10].transfers_from))
+        self.assertEqual(1, len(self.schedule.trips[10].transfers_to))
+        self.assertEqual([3], [tr.transfer_type for tr in self.schedule.trips[8].transfers_from])
+        self.assertEqual([], [tr.transfer_type for tr in self.schedule.trips[8].transfers_to])
+        self.assertEqual([], [tr.transfer_type for tr in self.schedule.trips[10].transfers_from])
+        self.assertEqual([3], [tr.transfer_type for tr in self.schedule.trips[10].transfers_to])
 
     def test_trips_bikes_allowed(self):
         for t in self.schedule.trips:


### PR DESCRIPTION
This PR adds support for trip-to-trip and route-to-route transfers.

These kind of transfers were previously an extension of the GTFS format, but have recently been incorporated in the specifications. Since pygtfs uses (from_stop_id, to_stop_id) as a primary key, it cannot import GTFS feeds where there are multiple entries for the same combination of stops, but with different trips or routes.

An example GTFS file with trip to trip transfers can be found here: https://www.bart.gov/dev/schedules/google_transit.zip

```
from_stop_id,to_stop_id,transfer_type,min_transfer_time,from_route_id,to_route_id,from_trip_id,to_trip_id
BAYF,BAYF,2,120,4,6,,
BAYF,BAYF,2,120,6,4,,
BAYF,BAYF,2,120,6,12,,
BAYF,BAYF,2,120,12,6,,
24TH,24TH,2,20,,,976865,983738
24TH,24TH,2,20,,,976861,983763
24TH,24TH,2,20,,,976837,983766
24TH,24TH,2,20,,,976838,983739
```

Other users seem to have encountered the same problem when ingesting data from BART: #61 should be fixed as well by this PR

While fixing this PR, I also updated the BART data which is used in unit tests, it was 3 years old, and their feed has changed a lot since then. While doing this, I found a bug in the Stop model, where `parent_station` was defined as an integer, while it refers to a Unicode id. `parent_station `has been updated to reflect the spec by allowing unicode values.

Not all Travis-CI tests are passing since there is one pre-existing bug left, see https://github.com/jarondl/pygtfs/issues/62

On a side note: Any change for this project to participate in Hacktoberfest, so PRs count toward a planted tree? https://hacktoberfest.digitalocean.com/