### PR TITLE
Add additional route types 

### DIFF
--- a/pygtfs/gtfs_entities.py
+++ b/pygtfs/gtfs_entities.py
@@ -200,6 +200,7 @@ class Route(Base):
     # https://developers.google.com/transit/gtfs/reference/extended-route-types
     valid_extended_route_types = [
         range(8),
+        range(11, 13),
         range(100, 118),
         range(200, 210),
         [300],


### PR DESCRIPTION
This PR adds two route types:

11 - trolleybus
12 - monorail

source: https://developers.google.com/transit/gtfs/reference#routestxt (in the route_type  description)

The route type 11 is used by Dopravný podnik Bratislava, https://opendata.bratislava.sk/dataset/show/cestovny-poriadok-20211025 (page in Slovak language).