### PR TITLE
TypeError and route type 717

### DIFF
--- a/pygtfs/gtfs_entities.py
+++ b/pygtfs/gtfs_entities.py
@@ -84,7 +84,7 @@ def _validate_float_none(*field_names):
     def is_float_none(self, key, value):
         try:
             return float(value)
-        except ValueError:
+        except (TypeError, ValueError):
             if value is None or value == "":
                 return None
             else:
@@ -206,7 +206,7 @@ class Route(Base):
         range(400, 406),
         [500],
         [600],
-        range(700, 717),
+        range(700, 718),
         [800],
         range(900, 907),
         range(1000, 1022),


### PR DESCRIPTION
Add TypeError as exception in is_float_none function.
Add route type 717 to valid range. 717 is not officially specified, but is used by many as Taxi service.