### PR TITLE
Simplify float validation logic

### DIFF
--- a/pygtfs/gtfs_entities.py
+++ b/pygtfs/gtfs_entities.py
@@ -82,13 +82,9 @@ def _validate_float_range(float_min, float_max, *field_names):
 def _validate_float_none(*field_names):
     @validates(*field_names)
     def is_float_none(self, key, value):
-        try:
-            return float(value)
-        except ValueError:
-            if value is None or value == "":
-                return None
-            else:
-                raise
+        if value is None or value == "":
+            return None
+        return float(value)
     return is_float_none
 
 


### PR DESCRIPTION
Resolves #58 

In `is_float_none`, the `except` block is not necessary. It exists to capture a `ValueError` and return `None` if `value` is `None` or `""`. However, `value` can never be `None` here because `float(None)` throws a `TypeError` (see issue #58) which is not caught. As well, if `value` is `""` then we return `None` and re-raise the error for any other value.

Instead, this conditional can be moved to the beginning of the function. Then, the `float(value)` will continue to raise exceptions for all non-`""` values, and `None` will correctly return `None`.