### PR TITLE
Update version specifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/jarondl/pygtfs',
     packages=find_packages(),
     install_requires=['sqlalchemy>=0.7.8',
-                      'pytz>=2012d',
+                      'pytz>=2012',
                       'six',
                       'docopt'
                       ],


### PR DESCRIPTION
Fixes:

```bash
error in pygtfs setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
    pytz>=2012d
```