### PR TITLE
Add Path (from pathlib) support to append_feed()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,6 @@
 ### Changed
 - input validation errors now raise ValueError, instead of AssertionError
 - Allow more values in `Stop.location_type` and in `Fare.transfers` (#27)
+- `pygtfs.append_feed` now accepts path-like objects (for example, `pathlib.Path`) in addition to string paths (#92)
 
 ## [0.1.3]

--- a/pygtfs/feed.py
+++ b/pygtfs/feed.py
@@ -51,13 +51,13 @@ class Feed(object):
     or loose in a folder."""
 
     def __init__(self, filename, strip_fields=True):
-        self.filename = filename
-        self.feed_name = derive_feed_name(filename)
+        self.filename = os.fspath(filename)
+        self.feed_name = derive_feed_name(self.filename)
         self.zf = None
         self.strip_fields = strip_fields
         self.empty_to_none = True
-        if not os.path.isdir(filename):
-            self.zf = ZipFile(filename)
+        if not os.path.isdir(self.filename):
+            self.zf = ZipFile(self.filename)
 
     def __repr__(self):
         return '<Feed %s>' % self.filename
@@ -88,4 +88,4 @@ class Feed(object):
 
 
 def derive_feed_name(filename):
-    return os.path.basename(filename.rstrip('/'))
+    return os.path.basename(os.path.normpath(os.fspath(filename)))

--- a/pygtfs/test/test.py
+++ b/pygtfs/test/test.py
@@ -3,9 +3,11 @@
 import datetime
 import os.path
 import unittest
+from pathlib import Path
 
 from pygtfs import overwrite_feed
 from pygtfs import Schedule
+from pygtfs.feed import Feed, derive_feed_name
 
 from sqlalchemy.orm import Query
 
@@ -129,6 +131,20 @@ class TestIgnoreFiles(unittest.TestCase):
     def test_services(self):
         ser = [service.service_id for service in self.schedule.services]
         self.assertEqual(ser, ["FULLW", "WE"])
+
+
+class TestPathInputs(unittest.TestCase):
+    def setUp(self):
+        self.data_location = Path(os.path.dirname(__file__)) / "data" / "sample_feed"
+
+    def test_derive_feed_name_accepts_path(self):
+        self.assertEqual(derive_feed_name(self.data_location), "sample_feed")
+        self.assertEqual(derive_feed_name(Path("/tmp/caltrain-ca-us.zip")),
+                         "caltrain-ca-us.zip")
+
+    def test_feed_accepts_path_for_directory_inputs(self):
+        agency_rows = Feed(self.data_location).reader("agency.txt")
+        self.assertEqual(next(agency_rows)[0], "agency_id")
 
 if __name__ == '__main__':
     unittest.main()

--- a/pygtfs/test/test.py
+++ b/pygtfs/test/test.py
@@ -2,8 +2,10 @@
 
 import datetime
 import os.path
+import tempfile
 import unittest
 from pathlib import Path
+from zipfile import ZipFile
 
 from pygtfs import overwrite_feed
 from pygtfs import Schedule
@@ -145,6 +147,29 @@ class TestPathInputs(unittest.TestCase):
     def test_feed_accepts_path_for_directory_inputs(self):
         agency_rows = Feed(self.data_location).reader("agency.txt")
         self.assertEqual(next(agency_rows)[0], "agency_id")
+
+    def test_feed_accepts_path_for_zip_file_inputs(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            zip_path = Path(temp_dir) / "sample_feed.zip"
+            with ZipFile(zip_path, "w") as zip_file:
+                for feed_file in self.data_location.iterdir():
+                    zip_file.write(feed_file, arcname=feed_file.name)
+
+            feed = Feed(zip_path)
+            agency_rows = feed.reader("agency.txt")
+
+            self.assertEqual(feed.feed_name, "sample_feed.zip")
+            self.assertEqual(next(agency_rows)[0], "agency_id")
+
+    def test_feed_handles_trailing_slash_in_directory_path(self):
+        path_with_trailing_slash = "{0}/".format(self.data_location)
+        feed = Feed(path_with_trailing_slash)
+        # the feed still opens as a directory-backed feed:
+        agency_rows = feed.reader("agency.txt")
+
+        self.assertEqual(feed.feed_name, "sample_feed")
+        self.assertEqual(next(agency_rows)[0], "agency_id")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When loading a feed:

```python
    schedule = pygtfs.Schedule("caltrain.sqlite")
    pygtfs.append_feed(schedule, gtfs_path)
```

the library expects `gtfs_path` to be a string.   
Many codebases prefer to use Path objects because they provide multiple useful methods. For example I can write something like this:

```python
    if not gtfs_path.exists():
        raise FileNotFoundError(f"GTFS file not found at: {gtfs_path}")
```

The PR implements Path object support. 
Once the PR is merged, library users can do:

```python
from pathlib import Path
import pygtfs

schedule = pygtfs.Schedule("caltrain.sqlite")
db_file_path = Path("/Users/dima/Downloads/caltrain-ca-us.zip")

pygtfs.append_feed(schedule, db_file_path)
# OR 
pygtfs.append_feed(schedule, "/Users/dima/Downloads/caltrain-ca-us.zip")
```

I hope you will find this change useful!